### PR TITLE
Throw io exception for fail firestore set up

### DIFF
--- a/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
+++ b/walk-in-interview/src/main/java/com/google/job/data/JobsDatabase.java
@@ -8,6 +8,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.utils.FireStoreUtils;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 
+import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -22,7 +23,7 @@ public final class JobsDatabase {
      * @param newJob Newly created job post. Assumes that it is non-nullable.
      * @return A future of the detailed information of the writing.
      */
-    public Future<WriteResult> addJob(Job newJob) {
+    public Future<WriteResult> addJob(Job newJob) throws IOException {
         // Add document data after generating an id.
         DocumentReference addedDocRef = FireStoreUtils.getFireStore()
                 .collection(JOB_COLLECTION).document();
@@ -46,7 +47,7 @@ public final class JobsDatabase {
      * @return A future of the detailed information of the update.
      * @throws IllegalArgumentException If the job id is invalid.
      */
-    public Future<WriteResult> setJob(String jobId, Job updatedJob) throws IllegalArgumentException {
+    public Future<WriteResult> setJob(String jobId, Job updatedJob) throws IllegalArgumentException, IOException {
         // Sets the Job with cloud firestore id and ACTIVE status
         Job job = updatedJob.toBuilder()
                 .setJobId(jobId)
@@ -65,7 +66,7 @@ public final class JobsDatabase {
      * @return Future of the target job post.
      * @throws IllegalArgumentException If the job id is invalid.
      */
-    public Future<Optional<Job>> fetchJob(String jobId) throws IllegalArgumentException {
+    public Future<Optional<Job>> fetchJob(String jobId) throws IllegalArgumentException, IOException {
         DocumentReference docRef = FireStoreUtils.getFireStore()
                 .collection(JOB_COLLECTION).document(jobId);
 
@@ -86,7 +87,7 @@ public final class JobsDatabase {
      * Returns a future of boolean to check if the job matching the given id is valid.
      * @throws IllegalArgumentException If the input jobId is empty.
      */
-    public static Future<Boolean> hasJob(String jobId) throws IllegalArgumentException {
+    public static Future<Boolean> hasJob(String jobId) throws IllegalArgumentException, IOException {
         if (jobId.isEmpty()) {
             throw new IllegalArgumentException("Empty Job Id");
         }

--- a/walk-in-interview/src/main/java/com/google/job/servlets/JobServlet.java
+++ b/walk-in-interview/src/main/java/com/google/job/servlets/JobServlet.java
@@ -108,7 +108,7 @@ public final class JobServlet extends HttpServlet {
             // Blocks the operation.
             // Use timeout in case it blocks forever.
             this.jobsDatabase.addJob(job).get(TIMEOUT, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | IOException e) {
             throw new ServletException(e);
         }
     }
@@ -123,7 +123,7 @@ public final class JobServlet extends HttpServlet {
             // Blocks the operation.
             // Use timeout in case it blocks forever.
             this.jobsDatabase.setJob(jobId, job).get(TIMEOUT, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | IOException e) {
             throw new ServletException(e);
         }
     }
@@ -141,7 +141,7 @@ public final class JobServlet extends HttpServlet {
             if (!hasJob) {
                 throw new IllegalArgumentException("Invalid Job Id");
             }
-        } catch (InterruptedException e) {
+        } catch (InterruptedException | IOException e) {
             throw new ServletException(e);
         }
     }

--- a/walk-in-interview/src/main/java/com/google/utils/FireStoreUtils.java
+++ b/walk-in-interview/src/main/java/com/google/utils/FireStoreUtils.java
@@ -41,14 +41,10 @@ public final class FireStoreUtils {
      * @return The only cloud firestore database.
      * @throws IOException If error occurs when creating database.
      */
-    public static Firestore getFireStore() {
+    public static Firestore getFireStore() throws IOException {
         if (firestore == null) {
-            try {
-                init();
-            } catch (IOException e) {
-                // TODO(issue/10.1): error handling
-                e.printStackTrace();
-            }
+            init();
+            // TODO(issue/10.1): error handling for IOException
         }
 
         return firestore;

--- a/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
+++ b/walk-in-interview/src/test/java/com/google/job/data/JobsDatabaseTest.java
@@ -5,6 +5,7 @@ import com.google.cloud.firestore.*;
 import com.google.utils.FireStoreUtils;
 import org.junit.*;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -24,7 +25,7 @@ public final class JobsDatabaseTest {
     static Firestore firestore;
 
     @BeforeClass
-    public static void setUp() {
+    public static void setUp() throws IOException {
         jobsDatabase = new JobsDatabase();
         firestore = FireStoreUtils.getFireStore();
     }
@@ -48,7 +49,7 @@ public final class JobsDatabaseTest {
     }
 
     @Test
-    public void addJob_normalInput_success() throws ExecutionException, InterruptedException {
+    public void addJob_normalInput_success() throws ExecutionException, InterruptedException, IOException {
         // Arrange.
         JobStatus expectedJobStatus = JobStatus.ACTIVE;
         String expectedJobName = "Software Engineer";
@@ -104,7 +105,7 @@ public final class JobsDatabaseTest {
     }
 
     @Test
-    public void setJob_normalInput_success() throws ExecutionException, InterruptedException {
+    public void setJob_normalInput_success() throws ExecutionException, InterruptedException, IOException {
         JobStatus expectedJobStatus = JobStatus.ACTIVE;
         String expectedJobName = "Noogler";
         Location expectedLocation =  new Location("Google", "123456", 0, 0);
@@ -166,7 +167,7 @@ public final class JobsDatabaseTest {
     }
 
     @Test
-    public void fetchJob_normalInput_success() throws ExecutionException, InterruptedException {
+    public void fetchJob_normalInput_success() throws ExecutionException, InterruptedException, IOException {
         // Arrange.
         JobStatus expectedJobStatus = JobStatus.ACTIVE;
         String expectedJobName = "Programmer";
@@ -210,7 +211,7 @@ public final class JobsDatabaseTest {
     }
 
     @Test
-    public void hasJob_normalInput_true() throws ExecutionException, InterruptedException, IllegalArgumentException {
+    public void hasJob_normalInput_true() throws ExecutionException, InterruptedException, IllegalArgumentException, IOException {
         // Arrange.
         Job job = new Job();
         Future<DocumentReference> addedJobFuture = firestore.collection(TEST_JOB_COLLECTION).add(job);
@@ -241,7 +242,7 @@ public final class JobsDatabaseTest {
     }
 
     @Test
-    public void hasJob_invalidJobId_false() throws ExecutionException, InterruptedException, IllegalArgumentException {
+    public void hasJob_invalidJobId_false() throws ExecutionException, InterruptedException, IllegalArgumentException, IOException {
         // Arrange.
         Job job = new Job();
         firestore.collection(TEST_JOB_COLLECTION).add(job);


### PR DESCRIPTION
As per title, instead of try-catch and print the stack trace, just throw the error so that it can directly shows it is a cloud firestore set up fail